### PR TITLE
Remove unnecessary second call to get_auth_code()

### DIFF
--- a/myfitbit/__init__.py
+++ b/myfitbit/__init__.py
@@ -86,7 +86,6 @@ class FitbitAuth(object):
         if os.path.isfile(self.ACCESS_TOKEN_FILE):
             self.access_token = json.load(open(self.ACCESS_TOKEN_FILE))
             return
-        self.get_auth_code()
         self.access_token = self.get_access_token()
         with open(self.ACCESS_TOKEN_FILE, 'w') as f:
             json.dump(self.access_token, f, sort_keys=True, indent=2)


### PR DESCRIPTION
It doesn't work for me unless I comment/delete this line.

In `ensure_access_token`,  `self.get_auth_code()` is called but the return value isn't caught, and nothing is cached anywhere.

In the call to `get_access_token` that happens when there isn't a valid token yet, the `get_auth_code` function is called and the return value is actually used.